### PR TITLE
Bump freva_rest version to 2509.0.0

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -7,6 +7,12 @@ What's new
    :maxdepth: 0
    :titlesonly:
 
+v2509.2.0
+~~~~~~~~
+* Bumped version of freva_rest to 2509.0.0
+
+
+
 v2509.1.0
 ~~~~~~~~
 * Bumped version of freva-web to 2509.0.0

--- a/src/freva_deployment/__init__.py
+++ b/src/freva_deployment/__init__.py
@@ -1,7 +1,7 @@
 import argparse
 from urllib.request import urlretrieve
 
-__version__ = "2509.1.0"
+__version__ = "2509.2.0"
 
 FREVA_PYTHON_VERSION = "3.13"
 AVAILABLE_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
This PR auto bumps the version of freva_rest to 2509.0.0. After the PR is merged you can create a new release of the deployment software by creating a tag with the name v2509.0.0 or, better by following the release procedure:

```console
tox -e release
```
